### PR TITLE
remove workbench-model-commons

### DIFF
--- a/drools-workbench-models/drools-workbench-models-test-scenarios/pom.xml
+++ b/drools-workbench-models/drools-workbench-models-test-scenarios/pom.xml
@@ -21,11 +21,6 @@
   <dependencies>
 
     <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-workbench-models-commons</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>compile</scope>


### PR DESCRIPTION
@Rikkola hi, I found one unused dependency, I think it is worth to remove it.